### PR TITLE
Update GLSPEditorRegistry.java

### DIFF
--- a/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/GLSPEditorRegistry.java
+++ b/server/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/GLSPEditorRegistry.java
@@ -82,11 +82,11 @@ public class GLSPEditorRegistry {
          "Could not retrieve GLSP Editor. GLSP editor is not properly configured for clientId: " + clientId);
    }
 
-   private synchronized void partClosed(final IWorkbenchPartReference part) {
+   private void partClosed(final IWorkbenchPartReference part) {
       if (part.getPart(false) instanceof GLSPDiagramEditor) {
          GLSPDiagramEditor editor = (GLSPDiagramEditor) part.getPart(false);
          editor.notifyAboutToBeDisposed();
-         clientIdtoDiagramEditor.remove(editor.getClientId());
+         removeDiagramEditor(editor.getClientId());
       }
    }
 
@@ -95,6 +95,10 @@ public class GLSPEditorRegistry {
          GLSPDiagramEditor editor = (GLSPDiagramEditor) part.getPart(false);
          clientIdtoDiagramEditor.put(editor.getClientId(), editor);
       }
+   }
+   
+   private synchronized void removeDiagramEditor(final String clientID) {
+      clientIdtoDiagramEditor.remove(clientID);
    }
 
    class GLSPDiagramEditorPartListener implements IPartListener2 {


### PR DESCRIPTION
fixes [ Deadlock when saving by closing dirty editor (Eclipse IDE integration) #916 ](https://github.com/eclipse-glsp/glsp/issues/916)